### PR TITLE
Feat: add the `curry` and `apply` extensions for the `F1`

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,7 +5,8 @@ packages:
     dependency: "direct dev"
     description:
       name: pedantic
-      url: "https://pub.dartlang.org"
+      sha256: "67fc27ed9639506c856c840ccce7594d0bdcd91bc8d53d6e52359449a1d50602"
+      url: "https://pub.dev"
     source: hosted
     version: "1.11.1"
   pure:
@@ -14,6 +15,6 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0"
+    version: "0.2.0"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.12.0 <4.0.0"

--- a/lib/src/curry/extensions.dart
+++ b/lib/src/curry/extensions.dart
@@ -13,6 +13,12 @@ import 'package:pure/src/common/function_types.dart';
 ///
 /// Handy for partial application.
 /// {@endtemplate}
+extension Curry1X<A, T> on F1<A, T> {
+  /// {@macro extensions.curry}
+  F0<T> curry(A a) => () => this(a);
+}
+
+/// {@macro extensions.curry}
 extension Curry2X<A, B, T> on F2<A, B, T> {
   /// {@macro extensions.curry}
   T Function(B b) curry(A a) => (b) => this(a, b);

--- a/lib/src/partial_application/extensions.dart
+++ b/lib/src/partial_application/extensions.dart
@@ -8,6 +8,12 @@ import 'package:pure/src/common/function_types.dart';
 /// Essentially acts as a shortcut of currying a function, applying the first
 /// argument and immediately uncurrying it back.
 /// {@endtemplate}
+extension Apply1X<A, T> on F1<A, T> {
+  /// {@macro extensions.partial_application}
+  F0<T> apply(A a) => () => this(a);
+}
+
+/// {@macro extensions.partial_application}
 extension Apply2X<A, B, T> on F2<A, B, T> {
   /// {@macro extensions.partial_application}
   F1<B, T> apply(A a) => (b) => this(a, b);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,8 +5,9 @@ packages:
     dependency: "direct dev"
     description:
       name: purple_lints
-      url: "https://pub.dartlang.org"
+      sha256: e8050113a2fc44ae6276bcbbf9c5b53e6f0f76a90657ce8278ac84efa8154cbc
+      url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.12.0 <4.0.0"


### PR DESCRIPTION
Hello

This pr adds the `curry` and `apply` extensions for a function with one argument